### PR TITLE
revert: 途中終了時の挙動をリバート (Issue #5)

### DIFF
--- a/src/components/chat/ChatInterface.tsx
+++ b/src/components/chat/ChatInterface.tsx
@@ -87,8 +87,7 @@ export function ChatInterface({ topicId }: { topicId: string }) {
         // Fallback: Save to local storage just in case
         localStorage.setItem('interview-messages', JSON.stringify(messages));
 
-        // Redirect to top screen
-        router.push('/');
+        router.push(`/report/${topicId}?interviewId=${interviewId}`);
     };
 
     if (sessionError) {


### PR DESCRIPTION
Issue #5「途中終了時の挙動変更」をリバート。
途中終了ボタンのリダイレクト先をトップ画面(/)からレポートページに戻す。

Closes #7

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the post-interview flow to navigate to the interview report page with relevant details instead of returning to the home screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->